### PR TITLE
Add fastifyOptions settings param

### DIFF
--- a/packages/bolt-core/src/route.ts
+++ b/packages/bolt-core/src/route.ts
@@ -6,6 +6,7 @@ export interface RouteSettings {
   validateBody?: boolean;
   validateParams?: boolean;
   fastifyConfig?: Record<string, any>;
+  fastifyOptions?: Record<string, any>;
 }
 
 export interface RouteConfigTypes {

--- a/packages/bolt-fastify/src/index.ts
+++ b/packages/bolt-fastify/src/index.ts
@@ -88,6 +88,7 @@ export class BoltServer<T extends RouterRecord> {
         continue;
       }
       this.server.route({
+        ...(route._def.settings.fastifyOptions ?? {}),
         method: route._def.method ?? 'GET',
         url: route._def.path as string,
         ...route._def.settings?.fastifyConfig && {


### PR DESCRIPTION
To do things like that 

```
const router = createRouter({
  websocket: route('/websocket').settings({ fastifyOptions: { websocket: true } })
});
```

```
fastify.get('/', { websocket: true }, (connection, req) => {
  connection.socket.on('message', (_) => {
    connection.socket.send('hi from server')
  })
})
```